### PR TITLE
Turn ram_size into float

### DIFF
--- a/scripts/init.groovy
+++ b/scripts/init.groovy
@@ -274,7 +274,7 @@ if (python_version_p == null)
 
 ram_size_p = mgmt.getPropertyKey('ram_size')
 if (ram_size_p == null)
-  ram_size_p = mgmt.makePropertyKey('ram_size').dataType(Integer.class).cardinality(org.janusgraph.core.Cardinality.SINGLE).make()
+  ram_size_p = mgmt.makePropertyKey('ram_size').dataType(Float.class).cardinality(org.janusgraph.core.Cardinality.SINGLE).make()
 
 release_p = mgmt.getPropertyKey('release')
 if (release_p == null)


### PR DESCRIPTION
It was not possible to sync some documents as JanusGraph serializer uses fixed
size of integer (32 bits) which caused errors when serializing/deserializing
data.

Fixes: #41